### PR TITLE
Add Reload, LoadProfileFromBytes and IsEnabled API

### DIFF
--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -22,3 +22,18 @@ func LoadProfile(body string, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 func GetDefaultProfile(rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 	return nil, fmt.Errorf("Seccomp not supported on this platform")
 }
+
+// LoadProfileFromBytes takes a byte slice and decodes the seccomp profile.
+func LoadProfileFromBytes(body []byte, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
+	return nil, fmt.Errorf("Seccomp not supported on this platform")
+}
+
+// Reload takes a Seccomp struct and a spec to reload the config
+func Reload(config *Seccomp, specgen *specs.Spec) error {
+	return fmt.Errorf("Seccomp not supported on this platform")
+}
+
+// IsEnabled returns true if seccomp is enabled for the host.
+func IsEnabled() bool {
+	return false
+}


### PR DESCRIPTION
This PR references to https://github.com/cri-o/cri-o/pull/2523, where we could get rid of the CRI-O internal implementation when adding the neccesary API paths here.