### PR TITLE
Fix missing import to finally build again

### DIFF
--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	libseccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
 )
 
 //go:generate go run -tags 'seccomp' generate.go


### PR DESCRIPTION
A small follow-up of #4, where the unix import was forgotten. :see_no_evil: 