### PR TITLE
add missing Docker copyright

### DIFF
--- a/seccomp_default_linux.go
+++ b/seccomp_default_linux.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2013-2018 Docker, Inc.
 
 package seccomp // import "github.com/seccomp/containers-golang"

--- a/seccomp_default_linux.go
+++ b/seccomp_default_linux.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// Copyright 2013-2018 Docker, Inc.
+
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (

--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2013-2018 Docker, Inc.
 
 package seccomp // import "github.com/seccomp/containers-golang"

--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// Copyright 2013-2018 Docker, Inc.
+
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2013-2018 Docker, Inc.
 
 package seccomp // import "github.com/seccomp/containers-golang"

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -1,5 +1,7 @@
 // +build seccomp
 
+// Copyright 2013-2018 Docker, Inc.
+
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (

--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -1,5 +1,7 @@
 // +build !seccomp
 
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2013-2018 Docker, Inc.
 
 package seccomp // import "github.com/seccomp/containers-golang"

--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -1,5 +1,7 @@
 // +build !seccomp
 
+// Copyright 2013-2018 Docker, Inc.
+
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package seccomp // import "github.com/seccomp/containers-golang"
 
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2013-2018 Docker, Inc.
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package seccomp // import "github.com/seccomp/containers-golang"
 
+// Copyright 2013-2018 Docker, Inc.
+
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
 	DefaultAction Action `json:"defaultAction"`


### PR DESCRIPTION
The package originates from the seccomp implementation in
github.com/moby/moby.  Add the copyright to properly
attribute the code's origin.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan PTAL