### PR TITLE
seccomp: generate smaller OCI configuration

### DIFF
--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -146,20 +146,20 @@ Loop:
 		}
 
 		if call.Name != "" {
-			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(call.Name, call.Action, call.Args))
+			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall([]string{call.Name}, call.Action, call.Args))
 		}
 
-		for _, n := range call.Names {
-			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(n, call.Action, call.Args))
+		if len(call.Names) > 0 {
+			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(call.Names, call.Action, call.Args))
 		}
 	}
 
 	return newConfig, nil
 }
 
-func createSpecsSyscall(name string, action Action, args []*Arg) specs.LinuxSyscall {
+func createSpecsSyscall(names []string, action Action, args []*Arg) specs.LinuxSyscall {
 	newCall := specs.LinuxSyscall{
-		Names:  []string{name},
+		Names:  names,
 		Action: specs.LinuxSeccompAction(action),
 	}
 


### PR DESCRIPTION
it is not needed to create a new configuration block for each syscall,
since the OCI runtime specs support to specify a set of syscall names.

The generated OCI spec file is much simpler (taken from podman run):

742 /tmp/config.json.new
2317 /tmp/config.json.old

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>