### PR TITLE
policy: ignore socket(AF_NETLINK, .*, NETLINK_AUDIT)

### DIFF
--- a/seccomp.json
+++ b/seccomp.json
@@ -317,7 +317,6 @@
 				"signalfd",
 				"signalfd4",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -766,6 +765,111 @@
 			"includes": {
 				"caps": [
 					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				},
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			},
+			"errnoRet": 22
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
 				]
 			},
 			"excludes": {}

--- a/seccomp_default_linux.go
+++ b/seccomp_default_linux.go
@@ -7,6 +7,8 @@
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (
+	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -45,6 +47,8 @@ func arches() []Architecture {
 
 // DefaultProfile defines the whitelist for the default seccomp profile.
 func DefaultProfile() *Seccomp {
+	einval := uint(syscall.EINVAL)
+
 	syscalls := []*Syscall{
 		{
 			Names: []string{
@@ -313,7 +317,6 @@ func DefaultProfile() *Seccomp {
 				"signalfd",
 				"signalfd4",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -650,6 +653,85 @@ func DefaultProfile() *Seccomp {
 			Args:   []*Arg{},
 			Includes: Filter{
 				Caps: []string{"CAP_SYS_TTY_CONFIG"},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &einval,
+			Args: []*Arg{
+				{
+					Index: 0,
+					Value: syscall.AF_NETLINK,
+					Op:    OpEqualTo,
+				},
+				{
+					Index: 2,
+					Value: syscall.NETLINK_AUDIT,
+					Op:    OpEqualTo,
+				},
+			},
+			Excludes: Filter{
+				Caps: []string{"CAP_AUDIT_WRITE"},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action: ActAllow,
+			Args: []*Arg{
+				{
+					Index: 2,
+					Value: syscall.NETLINK_AUDIT,
+					Op:    OpNotEqual,
+				},
+			},
+			Excludes: Filter{
+				Caps: []string{"CAP_AUDIT_WRITE"},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action: ActAllow,
+			Args: []*Arg{
+				{
+					Index: 0,
+					Value: syscall.AF_NETLINK,
+					Op:    OpNotEqual,
+				},
+			},
+			Excludes: Filter{
+				Caps: []string{"CAP_AUDIT_WRITE"},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action: ActAllow,
+			Args: []*Arg{
+				{
+					Index: 2,
+					Value: syscall.NETLINK_AUDIT,
+					Op:    OpNotEqual,
+				},
+			},
+			Excludes: Filter{
+				Caps: []string{"CAP_AUDIT_WRITE"},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action: ActAllow,
+			Includes: Filter{
+				Caps: []string{"CAP_AUDIT_WRITE"},
 			},
 		},
 	}


### PR DESCRIPTION
when running without CAP_AUDIT_WRITE make sure any call to
socket(AF_NETLINK, .*, NETLINK_AUDIT) fails with EINVAL.

In this way containers trying to write to the audit log, won't fail
since the seccomp filter will report errno == EINVAL (22), that in the
case of socket(2) means:

EINVAL Unknown protocol, or protocol family not available.

This feature requires a development version of Podman and crun/runc to
work.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>