### PR TITLE
Add GoArchToSeccompArch API function

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -1,0 +1,32 @@
+package seccomp // import "github.com/seccomp/containers-golang"
+
+import "fmt"
+
+var goArchToSeccompArchMap = map[string]Arch{
+	"386":         ArchX86,
+	"amd64":       ArchX86_64,
+	"amd64p32":    ArchX32,
+	"arm":         ArchARM,
+	"arm64":       ArchAARCH64,
+	"mips":        ArchMIPS,
+	"mips64":      ArchMIPS64,
+	"mips64le":    ArchMIPSEL64,
+	"mips64p32":   ArchMIPS64N32,
+	"mips64p32le": ArchMIPSEL64N32,
+	"mipsle":      ArchMIPSEL,
+	"ppc":         ArchPPC,
+	"ppc64":       ArchPPC64,
+	"ppc64le":     ArchPPC64LE,
+	"s390":        ArchS390,
+	"s390x":       ArchS390X,
+}
+
+// GoArchToSeccompArch converts a runtime.GOARCH to a seccomp `Arch`. The
+// function returns an error if the architecture conversion is not supported.
+func GoArchToSeccompArch(goArch string) (Arch, error) {
+	arch, ok := goArchToSeccompArchMap[goArch]
+	if !ok {
+		return "", fmt.Errorf("unsupported go arch provided: %s", goArch)
+	}
+	return arch, nil
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1,0 +1,27 @@
+package seccomp // import "github.com/seccomp/containers-golang"
+
+import (
+	"testing"
+)
+
+func TestGoArchToSeccompArchSuccess(t *testing.T) {
+	for goArch, seccompArch := range goArchToSeccompArchMap {
+		res, err := GoArchToSeccompArch(goArch)
+		if err != nil {
+			t.Fatalf("expected nil, but got error: %v", err)
+		}
+		if seccompArch != res {
+			t.Fatalf("expected %s, but got: %s", seccompArch, res)
+		}
+	}
+}
+
+func TestGoArchToSeccompArchFailure(t *testing.T) {
+	res, err := GoArchToSeccompArch("wrong")
+	if err == nil {
+		t.Fatal("expected error, but got nil")
+	}
+	if res != "" {
+		t.Fatalf("expected empty res, but got: %s", res)
+	}
+}


### PR DESCRIPTION
This helper allows us to convert a runtime.GOARCH to a seccomp `Arch`.
If the conversion is not possible then we return an error as expected.

Required for https://github.com/containers/oci-seccomp-bpf-hook/pull/55