### PR TITLE
Add additional seccomp architectures

### DIFF
--- a/types.go
+++ b/types.go
@@ -27,6 +27,7 @@ type Arch string
 // Additional architectures permitted to be used for system calls
 // By default only the native architecture of the kernel is permitted
 const (
+	ArchNative      Arch = "SCMP_ARCH_NATIVE"
 	ArchX86         Arch = "SCMP_ARCH_X86"
 	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
 	ArchX32         Arch = "SCMP_ARCH_X32"
@@ -43,6 +44,9 @@ const (
 	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
 	ArchS390        Arch = "SCMP_ARCH_S390"
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
+	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
+	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
+	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
 )
 
 // Action taken upon Seccomp rule match


### PR DESCRIPTION
Seccomp supports the additional arches `SCMP_ARCH_NATIVE`, `SCMP_ARCH_PARISC`, `SCMP_ARCH_PARISC64`, `SCMP_ARCH_RISCV64`, which are now included in the list as well.

PS: Not quite sure if we should add `SCMP_ARCH_NATIVE`, at least it's referenced in the doc comment above the definition block. :thinking: 