### PR TITLE
Unify errors for unsupported seccomp

### DIFF
--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -7,10 +7,12 @@
 package seccomp // import "github.com/seccomp/containers-golang"
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+var errNotSupported = errors.New("seccomp not enabled in this build")
 
 // DefaultProfile returns a nil pointer on unsupported systems.
 func DefaultProfile() *Seccomp {
@@ -19,22 +21,22 @@ func DefaultProfile() *Seccomp {
 
 // LoadProfile returns an error on unsuppored systems
 func LoadProfile(body string, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
-	return nil, fmt.Errorf("Seccomp not supported on this platform")
+	return nil, errNotSupported
 }
 
 // GetDefaultProfile returns an error on unsuppored systems
 func GetDefaultProfile(rs *specs.Spec) (*specs.LinuxSeccomp, error) {
-	return nil, fmt.Errorf("Seccomp not supported on this platform")
+	return nil, errNotSupported
 }
 
 // LoadProfileFromBytes takes a byte slice and decodes the seccomp profile.
 func LoadProfileFromBytes(body []byte, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
-	return nil, fmt.Errorf("Seccomp not supported on this platform")
+	return nil, errNotSupported
 }
 
 // LoadProfileFromConfig takes a Seccomp struct and a spec to retrieve a LinuxSeccomp
 func LoadProfileFromConfig(config *Seccomp, specgen *specs.Spec) (*specs.LinuxSeccomp, error) {
-	return nil, fmt.Errorf("Seccomp not supported on this platform")
+	return nil, errNotSupported
 }
 
 // IsEnabled returns true if seccomp is enabled for the host.


### PR DESCRIPTION
To remove the message repetition we now use a global error type to avoid
the noise.

We also change the error message to point out that its not enabled by
the build, but may be enabled by the host.