### PR TITLE
Add support to SCMP_ACT_LOG

### DIFF
--- a/types.go
+++ b/types.go
@@ -59,6 +59,7 @@ const (
 	ActErrno Action = "SCMP_ACT_ERRNO"
 	ActTrace Action = "SCMP_ACT_TRACE"
 	ActAllow Action = "SCMP_ACT_ALLOW"
+	ActLog   Action = "SCMP_ACT_LOG"
 )
 
 // Operator used to match syscall arguments in Seccomp


### PR DESCRIPTION
The proposed PR adds support to `SCMP_ACT_LOG`, which links back to `SECCOMP_RET_LOG` - added on Linux 4.14. 

More information:
https://man7.org/linux/man-pages/man3/seccomp_init.3.html
https://man7.org/linux/man-pages/man2/seccomp.2.html