### PR TITLE
Add support to ActKillProcess

### DIFF
--- a/types.go
+++ b/types.go
@@ -54,12 +54,15 @@ type Action string
 
 // Define actions for Seccomp rules
 const (
-	ActKill  Action = "SCMP_ACT_KILL"
-	ActTrap  Action = "SCMP_ACT_TRAP"
-	ActErrno Action = "SCMP_ACT_ERRNO"
-	ActTrace Action = "SCMP_ACT_TRACE"
-	ActAllow Action = "SCMP_ACT_ALLOW"
-	ActLog   Action = "SCMP_ACT_LOG"
+	// ActKill results in termination of the thread that made the system call.
+	ActKill Action = "SCMP_ACT_KILL"
+	// ActKillProcess results in termination of the entire process.
+	ActKillProcess Action = "SCMP_ACT_KILL_PROCESS"
+	ActTrap        Action = "SCMP_ACT_TRAP"
+	ActErrno       Action = "SCMP_ACT_ERRNO"
+	ActTrace       Action = "SCMP_ACT_TRACE"
+	ActAllow       Action = "SCMP_ACT_ALLOW"
+	ActLog         Action = "SCMP_ACT_LOG"
 )
 
 // Operator used to match syscall arguments in Seccomp


### PR DESCRIPTION
Added the `ActKillProcess` option, which allows for killing the entire process instead of just the thread, as `ActKill` does.

In the Kernel, when `ActKillProcess` was created (4.14) an extra `ActKillThread` action was also added to remove ambiguity.  `ActKill` was kept for backwards compatibility, so I wonder whether is it worth doing the same here or just the extra comments are sufficient?

More info:
https://man7.org/linux/man-pages/man2/seccomp.2.html

Signed-off-by: Paulo Gomes <pjbgf@linux.com>