### PR TITLE
Make DefaultProfile() work without seccomp build tag

### DIFF
--- a/seccomp_default_linux.go
+++ b/seccomp_default_linux.go
@@ -1,5 +1,3 @@
-// +build seccomp
-
 // SPDX-License-Identifier: Apache-2.0
 
 // Copyright 2013-2018 Docker, Inc.

--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -14,11 +14,6 @@ import (
 
 var errNotSupported = errors.New("seccomp not enabled in this build")
 
-// DefaultProfile returns a nil pointer on unsupported systems.
-func DefaultProfile() *Seccomp {
-	return nil
-}
-
 // LoadProfile returns an error on unsuppored systems
 func LoadProfile(body string, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 	return nil, errNotSupported


### PR DESCRIPTION
The types are exposed even if the build tag does not exist, which means
that we can also return the `DefaultProfile()` and their values.
